### PR TITLE
Added port manipulation

### DIFF
--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request_target:
-    branches:
-      - main
 
 jobs:
   get_default_envs:

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,6 +1,12 @@
 name: PlatformIO CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
 
 jobs:
   get_default_envs:

--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@
 
 This project aims to create a Brushed Electronic Speed Controller (ESC) using KiCad. The ESC is designed to control the speed of a brushed DC motor using pulse-width modulation (PWM) signals.
 
-## Components
-
-### MOSFETs:
-- BSC340N08NS3
-- ISC037N03L5ISATMA1
-
-### Driver:
-- TC4427
-
 ## Getting Started
 
 To get started with this project, follow these steps:
@@ -28,5 +19,46 @@ To get started with this project, follow these steps:
    ```bash
    git clone https://github.com/Witty-Wizard/Brushed-Speed-Controller.git
    ```
+
+## Port Manipulation
+
+Port manipulation is a method used to directly control the state of GPIO (General Purpose Input/Output). Instead of using digitalWrite() and digitalRead() functions, which are higher-level abstractions, port manipulation accesses the hardware registers directly.
+
+### Clearing a Bit in a Register
+
+To clear a bit in a register, you typically perform a bitwise AND operation between the register and the complement of a bitmask that has the desired bit set.
+
+```c
+register &= ~(1 << bit_position);
+```
+
+### Setting a Bit in a Register
+
+To set a bit in a register, you typically perform a bitwise OR operation between the register and a bitmask that has the desired bit set.
+
+```c
+register |= (1 << bit_position);
+```
+
+### Example
+
+- Setting Pin as Output
+
+  ```C
+  DDRD |= (1 << PD5);
+  ```
+
+- Turning Pin High
+
+  ```c
+  PORTD |= (1 << PD5);
+  ```
+
+- Turning Pin Low
+  ```c
+  PORTD &= ~(1 << PD5);
+  ```
+
 ## License
-This project is licensed under the GNU General Public License v3.0. You can find more details in the LICENSE file.
+
+This project is licensed under the GNU General Public License v3.0. You can find more details in the [LICENSE](LICENSE) file.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,221 +1,174 @@
 #include <Arduino.h>
 
-#define deadtime 2 // us
-#define motor1_PMOS 6
-#define motor1_NMOS 5
-enum output_state
-{
-  OUTPUT_HIGH = 1,
-  OUTPUT_LOW = 2,
-  OUTPUT_NEUTRAL = 0
-};
+#define deadtime 2      // us
+#define MOTOR1_PMOS PD6 // Pin 6 of ardunio nano
+#define MOTOR1_NMOS PD5 // Pin 5 of arduino nano
+enum output_state { OUTPUT_HIGH = 1, OUTPUT_LOW = 2, OUTPUT_NEUTRAL = 0 };
 
 output_state motor1 = OUTPUT_NEUTRAL;
 
 void output_fsm(output_state desired_state);
 
-void setup()
-{
+void setup() {
   // put your setup code here, to run once:
   Serial.begin(9600);
-  pinMode(motor1_PMOS, OUTPUT);
-  pinMode(motor1_NMOS, OUTPUT);
-
-  output_fsm(OUTPUT_NEUTRAL);
+  DDRD |=
+      (1 << MOTOR1_PMOS) | (1 << MOTOR1_NMOS); // define Pin 5 and 6 as output
+  output_fsm(OUTPUT_NEUTRAL); // initialise fsm with neutral state
 }
 
-void loop()
-{
+void loop() {
   // put your main code here, to run repeatedly:
-  while (Serial.available() > 0)
-  {
+  while (Serial.available() > 0) {
 
     char c = Serial.read();
-    if (c == '1')
-    {
+    if (c == '1') {
       output_fsm(OUTPUT_HIGH);
-    }
-    else if (c == '0')
-    {
+    } else if (c == '0') {
       output_fsm(OUTPUT_LOW);
-    }
-    else if (c == 'z')
-    {
+    } else if (c == 'z') {
       output_fsm(OUTPUT_NEUTRAL);
     }
   }
 }
 
-void output_fsm(output_state desired_state)
-{
-  if (motor1 == OUTPUT_NEUTRAL)
-  {
-    if (desired_state == OUTPUT_NEUTRAL)
-    {
+void output_fsm(output_state desired_state) {
+  if (motor1 == OUTPUT_NEUTRAL) {
+    if (desired_state == OUTPUT_NEUTRAL) {
 // turn both MOS OFF
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
 
       motor1 = OUTPUT_NEUTRAL;
-    }
-    else if (desired_state == OUTPUT_HIGH)
-    {
+    } else if (desired_state == OUTPUT_HIGH) {
 // turn pmos on
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD &= ~(1 << MOTOR1_NMOS) & ~(1 << MOTOR1_PMOS); // Pin 5 and 6 LOW
 #else
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD |= (1 << MOTOR1_NMOS) | (1 << MOTOR1_PMOS); // Pin 5 and 6 HIGH
 #endif
       motor1 = OUTPUT_HIGH;
-    }
-    else if (desired_state == OUTPUT_LOW)
-    {
+    } else if (desired_state == OUTPUT_LOW) {
 // turn nmos on
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD |= (1 << MOTOR1_NMOS) | (1 << MOTOR1_PMOS); // Pin 5 and 6 HIGH
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD &= ~(1 << MOTOR1_NMOS) & ~(1 << MOTOR1_PMOS); // Pin 5 and 6 LOW
 #endif
       motor1 = OUTPUT_LOW;
-    }
-    else
-    {
+    } else {
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       motor1 = OUTPUT_NEUTRAL;
     }
-  }
-  else if (motor1 == OUTPUT_HIGH)
-  {
-    if (desired_state == OUTPUT_NEUTRAL)
-    {
+  } else if (motor1 == OUTPUT_HIGH) {
+    if (desired_state == OUTPUT_NEUTRAL) {
 // turn both mos OFF
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       delayMicroseconds(deadtime);
       motor1 = OUTPUT_NEUTRAL;
-    }
-    else if (desired_state == OUTPUT_HIGH)
-    {
+    } else if (desired_state == OUTPUT_HIGH) {
 // turn pmos on
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD |= (1 << MOTOR1_PMOS); // Pin6 HIGH
+      PORTD |= (1 << MOTOR1_NMOS); // Pin5 HIGH
 #endif
       motor1 = OUTPUT_HIGH;
-    }
-    else if (desired_state == OUTPUT_LOW)
-    {
+    } else if (desired_state == OUTPUT_LOW) {
 // turn pmos off
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       delayMicroseconds(deadtime);
       motor1 = OUTPUT_NEUTRAL;
 
       // now turn on the mos
       output_fsm(OUTPUT_LOW);
-    }
-    else
-    {
+    } else {
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       motor1 = OUTPUT_NEUTRAL;
     }
-  }
-  else if (motor1 == OUTPUT_LOW)
-  {
-    if (desired_state == OUTPUT_NEUTRAL)
-    {
+  } else if (motor1 == OUTPUT_LOW) {
+    if (desired_state == OUTPUT_NEUTRAL) {
 // turn both MOS OFF
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       delayMicroseconds(deadtime);
       motor1 = OUTPUT_NEUTRAL;
-    }
-    else if (desired_state == OUTPUT_HIGH)
-    {
+    } else if (desired_state == OUTPUT_HIGH) {
 // turn nmos off
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       delayMicroseconds(deadtime);
       motor1 = OUTPUT_NEUTRAL;
 
       output_fsm(OUTPUT_HIGH);
-    }
-    else if (desired_state == OUTPUT_LOW)
-    {
+    } else if (desired_state == OUTPUT_LOW) {
 // turn nmos on
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD |= (1 << MOTOR1_PMOS); // Pin6 HIGH
+      PORTD |= (1 << MOTOR1_NMOS); // Pin5 HIGH
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #endif
       motor1 = OUTPUT_LOW;
-    }
-    else
-    {
+    } else {
 #ifndef INVERTED_OUTPUTS
-      digitalWrite(motor1_PMOS, HIGH);
-      digitalWrite(motor1_NMOS, LOW);
+      PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+      PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-      digitalWrite(motor1_PMOS, LOW);
-      digitalWrite(motor1_NMOS, HIGH);
+      PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+      PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
       motor1 = OUTPUT_NEUTRAL;
     }
-  }
-  else
-  {
+  } else {
 #ifndef INVERTED_OUTPUTS
-    digitalWrite(motor1_PMOS, HIGH);
-    digitalWrite(motor1_NMOS, LOW);
+    PORTD |= (1 << MOTOR1_PMOS);  // Pin6 HIGH
+    PORTD &= ~(1 << MOTOR1_NMOS); // Pin5 LOW
 #else
-    digitalWrite(motor1_PMOS, LOW);
-    digitalWrite(motor1_NMOS, HIGH);
+    PORTD &= ~(1 << MOTOR1_PMOS); // Pin6 LOW
+    PORTD |= (1 << MOTOR1_NMOS);  // Pin5 HIGH
 #endif
     motor1 = OUTPUT_NEUTRAL;
   }


### PR DESCRIPTION
## Description:
I propose the implementation of port manipulation for GPIO (General Purpose Input/Output) on Arduino Nano. Port manipulation allows for faster and more efficient control of digital pins compared to digitalRead() and digitalWrite() function.

## Implementation:
To implement port manipulation on Arduino Nano, the following steps can be followed:
- [x] Identify the port registers corresponding to the GPIO pins on the microcontroller used in Arduino Nano (typically ATmega328P).
- [x] Change README